### PR TITLE
Add PDF viewer example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Embedded PDF Reader</title>
+<style>
+  body, html {
+    height: 100%;
+    margin: 0;
+    font-family: sans-serif;
+  }
+  #viewer-container {
+    position: relative;
+    height: 100%;
+  }
+  canvas {
+    width: 100%;
+  }
+  #controls {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: rgba(255, 255, 255, 0.8);
+    padding: 5px;
+    z-index: 10;
+    display: flex;
+    gap: 5px;
+    align-items: center;
+  }
+</style>
+</head>
+<body>
+<div id="viewer-container">
+  <div id="controls">
+    <button id="prevPage">Prev</button>
+    <button id="nextPage">Next</button>
+    <button id="zoomOut">-</button>
+    <button id="zoomIn">+</button>
+    <span>Page <span id='page_num'>0</span> / <span id='page_count'>0</span></span>
+  </div>
+  <canvas id="pdf-canvas"></canvas>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.min.js"></script>
+<script>
+const url = 'sample.pdf'; // Replace with path to your PDF
+
+let pdfDoc = null,
+    pageNum = 1,
+    pageRendering = false,
+    pageNumPending = null,
+    scale = 1.0,
+    canvas = document.getElementById('pdf-canvas'),
+    ctx = canvas.getContext('2d');
+
+function renderPage(num) {
+  pageRendering = true;
+  pdfDoc.getPage(num).then(page => {
+    const viewport = page.getViewport({ scale });
+    canvas.height = viewport.height;
+    canvas.width = viewport.width;
+
+    const renderContext = {
+      canvasContext: ctx,
+      viewport
+    };
+    const renderTask = page.render(renderContext);
+
+    renderTask.promise.then(() => {
+      pageRendering = false;
+      document.getElementById('page_num').textContent = pageNum;
+      if (pageNumPending !== null) {
+        renderPage(pageNumPending);
+        pageNumPending = null;
+      }
+    });
+  });
+}
+
+function queueRenderPage(num) {
+  if (pageRendering) {
+    pageNumPending = num;
+  } else {
+    renderPage(num);
+  }
+}
+
+function onPrevPage() {
+  if (pageNum <= 1) return;
+  pageNum--;
+  queueRenderPage(pageNum);
+}
+
+function onNextPage() {
+  if (pageNum >= pdfDoc.numPages) return;
+  pageNum++;
+  queueRenderPage(pageNum);
+}
+
+function zoom(delta) {
+  scale = Math.min(Math.max(scale + delta, 0.5), 3);
+  queueRenderPage(pageNum);
+}
+
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.16.105/pdf.worker.min.js';
+
+pdfjsLib.getDocument(url).promise.then(function(pdfDoc_) {
+  pdfDoc = pdfDoc_;
+  document.getElementById('page_count').textContent = pdfDoc.numPages;
+  renderPage(pageNum);
+});
+
+// Attach events
+
+document.getElementById('prevPage').addEventListener('click', onPrevPage);
+document.getElementById('nextPage').addEventListener('click', onNextPage);
+document.getElementById('zoomOut').addEventListener('click', function() { zoom(-0.1); });
+document.getElementById('zoomIn').addEventListener('click', function() { zoom(0.1); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sample HTML page using pdf.js to render a PDF document with page navigation and zoom controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a3e4bc8148329ad5d6046350f2187